### PR TITLE
re-enable CI after org change

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -3,10 +3,10 @@ name: CI Additional
 on:
   push:
     branches:
-      - "*"
-  # pull_request:
-  #   branches:
-  #     - "*"
+      - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,9 @@ on:
   push:
     branches:
       - "*"
-  # pull_request:
-  #   branches:
-  #     - "*"
+  pull_request:
+    branches:
+      - "*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.md`

Let's check if the tests run again. xarray uses 
```
branches:
      - main
```

which I don't quite understand - should it not only run if on the main branch?