### PR TITLE
mpl: replace deprecated all_backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Internal changes
 
+- Replace deprecated `matplotlib.rcsetup.all_backends` with `matplotlib.backends.backend_registry.list_builtin()`
+  ([#160](https://github.com/mpytools/mplotutils/pull/160)).
 
 ## v0.6.0 (04.12.2024)
 

--- a/mplotutils/tests/test_get_renderer.py
+++ b/mplotutils/tests/test_get_renderer.py
@@ -6,7 +6,7 @@ from mplotutils import _get_renderer
 from . import figure_context, restore_backend
 
 
-@pytest.mark.parametrize("backend", matplotlib.rcsetup.all_backends)
+@pytest.mark.parametrize("backend", matplotlib.backends.backend_registry.list_builtin())
 def test_get_renderer(backend):
 
     with restore_backend(backend):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.md`

Should get upstream dev ci green again. 