### PR TITLE
switch to ruff

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,4 @@
 
  - [ ] Closes #xxx
  - [ ] Tests added
- - [ ] Passes `isort . && black . && flake8`
  - [ ] Fully documented, including `CHANGELOG.md`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,22 +8,14 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: mixed-line-ending
-    # This wants to go before isort & flake8
-  - repo: https://github.com/PyCQA/autoflake
-    rev: "v2.3.1"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.12.7'
     hooks:
-      - id: autoflake # isort should run before black as black sometimes tweaks the isort output
-        args: ["--in-place", "--ignore-init-module-imports"]
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
+      - id: ruff
+        args: ["--fix", "--show-fixes"]
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -30,6 +30,7 @@ IGNORE_DEPS = {
     "pytest-cov",
     "pytest-env",
     "pytest-xdist",
+    "ruff",
 }
 
 POLICY_MONTHS = {"python": 24, "numpy": 18, "setuptools": 42}

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -11,7 +11,6 @@ import itertools
 import sys
 from collections.abc import Iterator
 from datetime import datetime
-from typing import Optional
 
 import conda.api  # type: ignore[import]
 import yaml
@@ -58,7 +57,7 @@ def warning(msg: str) -> None:
     print("WARNING:", msg)
 
 
-def parse_requirements(fname) -> Iterator[tuple[str, int, int, Optional[int]]]:
+def parse_requirements(fname) -> Iterator[tuple[str, int, int, int | None]]:
     """Load requirements/py*-min-all-deps.yml
 
     Yield (package name, major version, minor version, [patch version])
@@ -129,7 +128,7 @@ def query_conda(pkg: str) -> dict[tuple[int, int], datetime]:
 
 
 def process_pkg(
-    pkg: str, req_major: int, req_minor: int, req_patch: Optional[int]
+    pkg: str, req_major: int, req_minor: int, req_patch: int | None
 ) -> tuple[str, str, str, str, str, str]:
     """Compare package version from requirements file to available versions in conda.
     Return row to build pandas dataframe:
@@ -141,7 +140,7 @@ def process_pkg(
     - publication date of version suggested by policy (YYYY-MM-DD)
     - status ("<", "=", "> (!)")
     """
-    print("Analyzing %s..." % pkg)
+    print(f"Analyzing {pkg}...")
     versions = query_conda(pkg)
 
     try:

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -10,8 +10,7 @@ dependencies:
   - xarray
 # formatting
   - black
-  - isort
-  - flake8
+  - ruff
 # for testing
   - pytest
   - pytest-cov

--- a/mplotutils/_cartopy_utils.py
+++ b/mplotutils/_cartopy_utils.py
@@ -327,7 +327,7 @@ def yticklabels(
     if not y_label_points:
         msg = (
             "WARN: no points found for ylabel\n"
-            "y_lim is: {:0.2f} to {:0.2f}".format(y_lim[0], y_lim[1])
+            f"y_lim is: {y_lim[0]:0.2f} to {y_lim[1]:0.2f}"
         )
         warnings.warn(msg)
 
@@ -427,7 +427,7 @@ def xticklabels(
     if not x_label_points:
         msg = (
             "WARN: no points found for xlabel\n"
-            "x_lim is: {:0.2f} to {:0.2f}".format(x_lim[0], x_lim[1])
+            f"x_lim is: {x_lim[0]:0.2f} to {x_lim[1]:0.2f}"
         )
         warnings.warn(msg)
 

--- a/mplotutils/_colormaps.py
+++ b/mplotutils/_colormaps.py
@@ -55,7 +55,7 @@ def _color_palette(cmap, n_colors):
     from matplotlib.colors import ListedColormap
 
     colors_i = np.linspace(0, 1.0, n_colors)
-    if isinstance(cmap, (list, tuple)):
+    if isinstance(cmap, list | tuple):
         # expand or truncate the list of colors to n_colors
         cmap = list(itertools.islice(itertools.cycle(cmap), n_colors))
         cmap = ListedColormap(cmap)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,32 @@ build-backend = "setuptools.build_meta"
 fallback_version = "999"
 version_scheme = "no-guess-dev"
 
+
+[tool.ruff]
+# also check notebooks
+extend-include = ["*.ipynb"]
+target-version = "py310"
+
+[tool.ruff.lint]
+# E402: module level import not at top of file
+# E501: line too long - let the formatter worry about this
+# E731: do not assign a lambda expression, use a def
+ignore = [
+  "E402",
+  "E501",
+  "E731",
+]
+select = [
+  "F", # Pyflakes
+  "E", # Pycodestyle
+  "W", # warnings
+  "I", # isort
+  "UP", # Pyupgrade
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["mplotutils"]
+
 [tool.pytest.ini_options]
 
 log_cli_level = "INFO"

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,23 +29,6 @@ install_requires =
     numpy >=1.26
     xarray >=2024.7
 
-[flake8]
-ignore=
-    # E203: whitespace before ':' - doesn't work well with black
-    # E402: module level import not at top of file
-    # E501: line too long - let black worry about that
-    # E731: do not assign a lambda expression, use a def
-    # W503: line break before binary operator
-    E203, E402, E501, E731, W503
-exclude =
-    build
-    docs
-    .git
-
-[isort]
-profile = black
-known_first_party = mplotutils
-
 [coverage:run]
 omit =
     */tests/*,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `CHANGELOG.md`

Preparation for consolidating all metadata to pyproject.toml. flake8 does not support _pyproject.toml_ and I am not keeping an extra config file around.